### PR TITLE
Iterate map styles

### DIFF
--- a/src/mapboxStyle.js
+++ b/src/mapboxStyle.js
@@ -1,33 +1,83 @@
+// Colors loosely based on https://whereis.mit.edu/
+const background = {
+  id: 'background',
+  type: 'background',
+  paint: {
+    'background-color': '#fcf9f0'
+  }
+};
+
+const roads = {
+  id: 'roads',
+  type: 'line',
+  source: 'campus',
+  filter: [
+    'all',
+    [ '==', '$type', 'LineString' ],
+  ],
+  paint: {
+    'line-color': '#dfb5b7'
+  }
+};
+
+const buildings = {
+  id: 'buildings',
+  type: 'fill',
+  source: 'campus',
+  filter: [ 'has', 'building' ],
+  paint: {
+    'fill-color': '#fcecae',
+    'fill-outline-color': '#c2b37b'
+  }
+};
+
+const grass = {
+  id: 'grass',
+  type: 'fill',
+  source: 'campus',
+  filter: [
+    'any',
+    [ '==', 'landuse', 'grass' ],
+    [ '==', 'surface', 'grass' ],
+    [ '==', 'landcover', 'grass' ],
+    [ '==', 'landuse', 'forest' ],
+    [ '==', 'landuse', 'recreation_ground' ],
+    [ '==', 'leisure', 'park' ],
+    [ '==', 'leisure', 'common' ],
+    [ '==', 'leisure', 'recreation_ground' ],
+  ],
+  paint: {
+    'fill-color': '#d0e9bd',
+  }
+};
+
+const sports = {
+  id: 'sports',
+  type: 'fill',
+  source: 'campus',
+  filter: [
+    'any',
+    [ '==', 'leisure', 'pitch' ],
+    [ '==', 'leisure', 'track' ],
+  ],
+  paint: {
+    'fill-color': '#cbddab'
+  }
+};
+
 export const mapboxStyle = {
   version: 8,
   sources: {
     campus: {
-      data: "rawGeo.json",
-      type: "geojson"
+      data: 'rawGeo.json',
+      type: 'geojson'
     }
   },
   layers: [
-    {
-      id: "background",
-      type: "background",
-      paint: {
-        "background-color": "white"
-      }
-    },
-    {
-      id: "highway",
-      type: "line",
-      source: "campus",
-      filter: [
-        "all",
-        [ "==", "$type", "LineString" ],
-      ],
-      layout: {
-        "line-join": "round"
-      },
-      paint: {
-        "line-color": 'red'
-      }
-    }
+    background,
+    grass,
+    sports,
+    buildings,
+    roads,
   ]
 };

--- a/src/mapboxStyle.js
+++ b/src/mapboxStyle.js
@@ -1,40 +1,22 @@
+const layers = [];
+
+const add = layer => {
+  layer.source = 'campus';
+  layers.push(layer);
+};
+
 // Colors loosely based on https://whereis.mit.edu/
-const background = {
+add({
   id: 'background',
   type: 'background',
   paint: {
     'background-color': '#fcf9f0'
   }
-};
+});
 
-const roads = {
-  id: 'roads',
-  type: 'line',
-  source: 'campus',
-  filter: [
-    'all',
-    [ '==', '$type', 'LineString' ],
-  ],
-  paint: {
-    'line-color': '#dfb5b7'
-  }
-};
-
-const buildings = {
-  id: 'buildings',
-  type: 'fill',
-  source: 'campus',
-  filter: [ 'has', 'building' ],
-  paint: {
-    'fill-color': '#fcecae',
-    'fill-outline-color': '#c2b37b'
-  }
-};
-
-const grass = {
+add({
   id: 'grass',
   type: 'fill',
-  source: 'campus',
   filter: [
     'any',
     [ '==', 'landuse', 'grass' ],
@@ -49,12 +31,11 @@ const grass = {
   paint: {
     'fill-color': '#d0e9bd',
   }
-};
+});
 
-const sports = {
+add({
   id: 'sports',
   type: 'fill',
-  source: 'campus',
   filter: [
     'any',
     [ '==', 'leisure', 'pitch' ],
@@ -63,7 +44,29 @@ const sports = {
   paint: {
     'fill-color': '#cbddab'
   }
-};
+});
+
+add({
+  id: 'buildings',
+  type: 'fill',
+  filter: [ 'has', 'building' ],
+  paint: {
+    'fill-color': '#fcecae',
+    'fill-outline-color': '#c2b37b'
+  }
+});
+
+add({
+  id: 'roads',
+  type: 'line',
+  filter: [
+    'all',
+    [ '==', '$type', 'LineString' ],
+  ],
+  paint: {
+    'line-color': '#dfb5b7'
+  }
+});
 
 export const mapboxStyle = {
   version: 8,
@@ -73,11 +76,5 @@ export const mapboxStyle = {
       type: 'geojson'
     }
   },
-  layers: [
-    background,
-    grass,
-    sports,
-    buildings,
-    roads,
-  ]
+  layers
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68416/48828970-1b613480-ed97-11e8-9bc5-27cb0aadc054.png)

Summary of changes:

 * Add buildings
 * Add green areas
 * Iterate colors based on https://whereis.mit.edu/
 * Put roads on top of buildings, to make indoor pedestrian ways visible
 * Refactor to reduce duplicated logic for map styles